### PR TITLE
Add Spring Boot search server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ IOS store = https://apps.apple.com/us/app/%EC%BF%A1%ED%94%8C-100%EB%A7%8C-%EC%9D
 AOS store = https://play.google.com/store/apps/details?id=com.devsheep.cookfluencer
 
 ![스크린샷 2025-01-03 오전 11 01 55](https://github.com/user-attachments/assets/60eddb90-77c8-43af-8a49-9c490cf55990)
+
+## Search Server
+
+A sample search server is provided under the `search-server` directory. It uses Spring Boot and Apache Lucene to index and search documents locally. See `search-server/README.md` for build and run instructions.

--- a/search-server/README.md
+++ b/search-server/README.md
@@ -1,0 +1,28 @@
+# Cookfluencer Search Server
+
+This module provides a simple search server implemented with Spring Boot and Apache Lucene. It can be used to replace cloud search services such as Algolia by running your own server.
+
+## Building
+
+Install JDK 17 and Maven. Then run:
+
+```bash
+mvn package
+```
+
+## Running
+
+After building, launch the server with:
+
+```bash
+java -jar target/search-server-0.0.1-SNAPSHOT.jar
+```
+
+The server listens on port `8080` by default.
+
+## API
+
+- `POST /api/documents` – Add a document to the index. JSON body fields: `id`, `title`, `content`.
+- `GET /api/search?query=...` – Search documents by query string. Returns a JSON array of matching documents.
+
+This example uses an in-memory index for simplicity. To persist data, integrate a database or file-based Lucene directory.

--- a/search-server/pom.xml
+++ b/search-server/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.cookfluencer</groupId>
+    <artifactId>search-server</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>9.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>9.9.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/search-server/src/main/java/com/cookfluencer/searchserver/Application.java
+++ b/search-server/src/main/java/com/cookfluencer/searchserver/Application.java
@@ -1,0 +1,11 @@
+package com.cookfluencer.searchserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/search-server/src/main/java/com/cookfluencer/searchserver/Document.java
+++ b/search-server/src/main/java/com/cookfluencer/searchserver/Document.java
@@ -1,0 +1,40 @@
+package com.cookfluencer.searchserver;
+
+public class Document {
+    private String id;
+    private String title;
+    private String content;
+
+    public Document() {
+    }
+
+    public Document(String id, String title, String content) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/search-server/src/main/java/com/cookfluencer/searchserver/SearchController.java
+++ b/search-server/src/main/java/com/cookfluencer/searchserver/SearchController.java
@@ -1,0 +1,29 @@
+package com.cookfluencer.searchserver;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @PostMapping("/documents")
+    public ResponseEntity<Void> addDocument(@RequestBody Document doc) throws Exception {
+        searchService.addDocument(doc);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Document>> search(@RequestParam("query") String query) throws Exception {
+        List<Document> results = searchService.search(query);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/search-server/src/main/java/com/cookfluencer/searchserver/SearchService.java
+++ b/search-server/src/main/java/com/cookfluencer/searchserver/SearchService.java
@@ -1,0 +1,55 @@
+package com.cookfluencer.searchserver;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class SearchService {
+
+    private final Analyzer analyzer = new StandardAnalyzer();
+    private final Directory index = new RAMDirectory();
+
+    public void addDocument(com.cookfluencer.searchserver.Document doc) throws Exception {
+        IndexWriterConfig config = new IndexWriterConfig(analyzer);
+        try (IndexWriter writer = new IndexWriter(index, config)) {
+            Document luceneDoc = new Document();
+            luceneDoc.add(new StringField("id", doc.getId(), Field.Store.YES));
+            luceneDoc.add(new TextField("title", doc.getTitle(), Field.Store.YES));
+            luceneDoc.add(new TextField("content", doc.getContent(), Field.Store.YES));
+            writer.addDocument(luceneDoc);
+        }
+    }
+
+    public List<com.cookfluencer.searchserver.Document> search(String queryStr) throws Exception {
+        List<com.cookfluencer.searchserver.Document> results = new ArrayList<>();
+        Query q = new QueryParser("content", analyzer).parse(queryStr);
+        try (DirectoryReader reader = DirectoryReader.open(index)) {
+            IndexSearcher searcher = new IndexSearcher(reader);
+            TopDocs docs = searcher.search(q, 10);
+            for (ScoreDoc sd : docs.scoreDocs) {
+                Document d = searcher.doc(sd.doc);
+                results.add(new com.cookfluencer.searchserver.Document(
+                        d.get("id"), d.get("title"), d.get("content")));
+            }
+        }
+        return results;
+    }
+}

--- a/search-server/src/main/resources/application.properties
+++ b/search-server/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=8080


### PR DESCRIPTION
## Summary
- add a basic Spring Boot search server using Apache Lucene
- document server build and usage instructions
- note server in root README

## Testing
- `javac -version`


------
https://chatgpt.com/codex/tasks/task_e_684fe3c2c15c832b925a85e6e204f189